### PR TITLE
fix steering angle

### DIFF
--- a/src/platforms/hunter_base.cpp
+++ b/src/platforms/hunter_base.cpp
@@ -69,16 +69,16 @@ void HunterBase::SetMotionCommand(
     linear_vel = HunterMotionCmd::min_linear_velocity;
   if (linear_vel > HunterMotionCmd::max_linear_velocity)
     linear_vel = HunterMotionCmd::max_linear_velocity;
-  if (steering_angle < HunterMotionCmd::min_steering_angle)
-    steering_angle = HunterMotionCmd::min_steering_angle;
-  if (steering_angle > HunterMotionCmd::max_steering_angle)
-    steering_angle = HunterMotionCmd::max_steering_angle;
+  // if (steering_angle < HunterMotionCmd::min_steering_angle)
+  //   steering_angle = HunterMotionCmd::min_steering_angle;
+  // if (steering_angle > HunterMotionCmd::max_steering_angle)
+  //   steering_angle = HunterMotionCmd::max_steering_angle;
 
   std::lock_guard<std::mutex> guard(motion_cmd_mutex_);
   current_motion_cmd_.linear_velocity_height_byte = static_cast<int16_t>(linear_vel*1000)>>8;
   current_motion_cmd_.linear_velocity_low_byte = static_cast<int16_t>(linear_vel*1000)&0xff;
-  current_motion_cmd_.angular_velocity_height_byte = static_cast<int16_t>(angular_vel*1000)>>8;
-  current_motion_cmd_.angular_velocity_low_byte = static_cast<int16_t>(angular_vel*1000)&0xff;
+  current_motion_cmd_.angular_velocity_height_byte = static_cast<int16_t>(steering_angle*1000)>>8;
+  current_motion_cmd_.angular_velocity_low_byte = static_cast<int16_t>(steering_angle*1000)&0xff;
   current_motion_cmd_.fault_clear_flag = fault_clr_flag;
 
   FeedCmdTimeoutWatchdog();


### PR DESCRIPTION
根据我们的理解和测试，下发的转向角应为steering_angle，而非angular_vel。在hunter_2_ros中，steering_angle由angular_vel经ConvertCentralAngleToInner转换得到，但未被使用。而steering_angle的范围应大于HunterMotionCmd::max_steering_angle当前值，故暂时注释掉。范围判断已在hunter_2_ros中做过，且底盘驱动中应该也有。
修改后可以看到转向角命令和反馈不再出现偏差。